### PR TITLE
Update tss.c

### DIFF
--- a/tsschecker/tss.c
+++ b/tsschecker/tss.c
@@ -100,7 +100,7 @@ char* ecid_to_string(uint64_t ecid) {
 		tsserror("ERROR: Invalid ECID passed.\n");
 		return NULL;
 	}
-	snprintf(ecid_string, ECID_STRSIZE, FMT_qu, (long long unsigned int)ecid);
+	snprintf(ecid_string, ECID_STRSIZE, "%"PRIu64, ecid);
 	return ecid_string;
 }
 
@@ -762,8 +762,12 @@ int tss_request_add_ap_tags(plist_t request, plist_t parameters, plist_t overrid
 
 		if (_plist_dict_get_bool(parameters, "_OnlyFWComponents")) {
 			plist_t info_dict = plist_dict_get_item(manifest_entry, "Info");
-			if (!_plist_dict_get_bool(manifest_entry, "Trusted") && !_plist_dict_get_bool(info_dict, "IsFirmwarePayload") && !_plist_dict_get_bool(info_dict, "IsSecondaryFirmwarePayload") && !_plist_dict_get_bool(info_dict, "IsFUDFirmware")) {
-				debug("DEBUG: %s: Skipping '%s' as it is neither firmware nor secondary firmware payload\n", __func__, key);
+			if (!_plist_dict_get_bool(manifest_entry, "Trusted")) {
+				debug("DEBUG: %s: Skipping '%s' as it is not trusted", __func__, key);
+				continue;
+			}
+			if (!_plist_dict_get_bool(info_dict, "IsFirmwarePayload") && !_plist_dict_get_bool(info_dict, "IsSecondaryFirmwarePayload") && !_plist_dict_get_bool(info_dict, "IsFUDFirmware")) {
+				debug("DEBUG: %s: Skipping '%s' as it is neither firmware nor secondary nor FUD firmware payload\n", __func__, key);
 				continue;
 			}
 		}
@@ -1585,7 +1589,7 @@ char* tss_request_send_raw(char* request, const char* server_url_string, int* re
         curl_easy_perform(handle);
         curl_slist_free_all(header);
         curl_easy_cleanup(handle);
-        
+
         if (strstr(response->content, "MESSAGE=SUCCESS")) {
             status_code = 0;
             info("success\n");


### PR DESCRIPTION
Fix logical bug in tss_request_add_ap_tags() when selecting 'only firmware components'
Remove trailing whitespace error from tss.c
Use uint64_t and appropriate standard PRI* format specifiers